### PR TITLE
MMA-7670 Oppdatert avro til 1.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
 
         <!-- Confluent-versjon 7.6.0 av kafka-avro-serializer bruker avro-versjon 1.11.3 -->
         <!-- Ved oppdatering av kafka-avro-serializer kan denne også oppdateres -->
-        <avro.version>1.11.3</avro.version>
+        <!-- https://github.com/confluentinc/schema-registry/issues/3318 -->
+        <avro.version>1.11.4</avro.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
https://avro.apache.org/blog/2024/09/22/avro-1.11.4/

Burde være kompatibel med `kafka-avro-serializer`, som har denne inkludert i neste versjon