### PR TITLE
MMA-7682 Legg til automatisk git tag og release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Endringer
+
+  $CHANGES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Deploy new package
+name: Build and tag
 
 on:
   push:
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,11 +28,22 @@ jobs:
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
           bump_each_commit: true
-      - name: Build and deploy
+      - name: Build
         shell: bash
         run: |
           echo "Setting tag ${{ steps.create-tag.outputs.version }}"
           mvn versions:set -DnewVersion="${{ steps.create-tag.outputs.version }}"
-          mvn deploy --batch-mode --settings ./settings.xml
+          mvn verify --batch-mode --settings ./settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push tag
+        run: |
+          git tag ${{ steps.create-tag.outputs.version }}
+          git push origin ${{ steps.create-tag.outputs.version }}
+      - name: Update release draft
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # 6.1.0
+        with:
+          tag: ${{ steps.create-tag.outputs.version }}
+          name: ${{ steps.create-tag.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish package
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Publish
+        shell: bash
+        run: |
+          echo "Publishing version ${{ github.event.release.tag_name }}"
+          mvn versions:set -DnewVersion="${{ github.event.release.tag_name }}"
+          mvn deploy --batch-mode --settings ./settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ Det er i hovedsak følgende applikasjoner som produserer Avro-meldinger:
     - [hoveddokumentLest](src/main/avro/safselvbetjening/hoveddokumentLest.avsc) er tilgjengelig på topic [privat-dokdistdittnav-lestavmottaker-q1](https://github.com/navikt/dokumenthandtering-iac/blob/master/kafka-aiven/privat-dokdistdittnav-lestavmottaker-q1/topic.yaml)
 
 ## Deploy av nye versjoner
-Det er semantisk versjonering av teamdokumenthandtering-avro-schemas-pakken, og alle commits vil lage en ny versjon av pakken. 
+Det er semantisk versjonering av teamdokumenthandtering-avro-schemas-pakken, og alle commits vil lage en ny versjon (tag). 
 Dersom oppdateringen skal være en major-versjon må commit-tittel inneholde tekststrengen `(MAJOR)`. Dersom commit-tittel inneholder `(MINOR)` vil versjonen bli en
 minor-versjon. Commits som ikke har noen av delene blir automatisk en patch-versjon.
+
+Maven-pakken, med endringslogg akkumulert av release-drafter, publiseres kun ved release.
 
 ### Henvendelser
 Spørsmål om koden eller prosjektet kan rettes til [Slack-kanalen for \#Team Dokumentløsninger](https://nav-it.slack.com/archives/C6W9E5GPJ).


### PR DESCRIPTION
Legger til:

- Automatisk opprettelse av git-tag ved push til master
- Delt bygg og deploy i to separate workflows
- `release-drafter.yml` for endringlogg

## Endringer
- **Git-tag per commit:** Etter vellykket bygg og deploy opprettes en git-tag med beregnet semantiske versjonen.
- **Release-draft med changelog:** `release-drafter` akkumulerer endringslogg i en draft-release som oppdateres ved hvert push til master.
- **README oppdatert** med beskrivelse av ny flyt.

## Ny flyt
| Trigger | Hva skjer |
|---|---|
| Push til master | Bygg → opprett git-tag → oppdater release-draft |
| Manuelt (GitHub Releases UI) | Teamet redigerer draft (fjerner irrelevante linjer) → publiserer release |

## Versjonering
Uendret fra før:
- `(MAJOR)` i commit-melding → major-bump
- `(MINOR)` i commit-melding → minor-bump
- Ellers → patch-bump

Versjonen i release-draften er alltid siste beregnede semantiske versjon.

Den som publiserer releasen går gjennom changelog og fjerner det som er irrelevant (f.eks. dependabot-bumps, småfikser).