### PR TITLE
MMA-7682 Skur av bump_each_commit for beregning av semver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           tag_prefix: ""
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
-          bump_each_commit: true
+          bump_each_commit: false
       - name: Build
         shell: bash
         run: |


### PR DESCRIPTION
Skruv av bump_each_commit for å unngå at versjoner bumpes flere gang ved merge (en gang pr commit i PR, og en gang for merge commit).