### PR TITLE
MMA-7682 Fjern semantic-version, forenkle build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and tag
+name: Build
 
 on:
   push:
@@ -20,30 +20,12 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-      - name: Create tag
-        uses: paulhatch/semantic-version@v6.0.2
-        id: create-tag
-        with:
-          tag_prefix: ""
-          major_pattern: "(MAJOR)"
-          minor_pattern: "(MINOR)"
-          bump_each_commit: false
       - name: Build
         shell: bash
-        run: |
-          echo "Setting tag ${{ steps.create-tag.outputs.version }}"
-          mvn versions:set -DnewVersion="${{ steps.create-tag.outputs.version }}"
-          mvn verify --batch-mode --settings ./settings.xml
+        run: mvn verify --batch-mode --settings ./settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push tag
-        run: |
-          git tag ${{ steps.create-tag.outputs.version }}
-          git push origin ${{ steps.create-tag.outputs.version }}
       - name: Update release draft
         uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # 6.1.0
-        with:
-          tag: ${{ steps.create-tag.outputs.version }}
-          name: ${{ steps.create-tag.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ Det er i hovedsak følgende applikasjoner som produserer Avro-meldinger:
     - [hoveddokumentLest](src/main/avro/safselvbetjening/hoveddokumentLest.avsc) er tilgjengelig på topic [privat-dokdistdittnav-lestavmottaker](https://github.com/navikt/dokumenthandtering-iac/blob/master/kafka-aiven/privat-dokdistdittnav-lestavmottaker/topic.yaml)
     - [hoveddokumentLest](src/main/avro/safselvbetjening/hoveddokumentLest.avsc) er tilgjengelig på topic [privat-dokdistdittnav-lestavmottaker-q1](https://github.com/navikt/dokumenthandtering-iac/blob/master/kafka-aiven/privat-dokdistdittnav-lestavmottaker-q1/topic.yaml)
 
-## Deploy av nye versjoner
-Det er semantisk versjonering av teamdokumenthandtering-avro-schemas-pakken, og alle commits vil lage en ny versjon (tag). 
-Dersom oppdateringen skal være en major-versjon må commit-tittel inneholde tekststrengen `(MAJOR)`. Dersom commit-tittel inneholder `(MINOR)` vil versjonen bli en
-minor-versjon. Commits som ikke har noen av delene blir automatisk en patch-versjon.
+## Release av nye versjoner
+Publiser release via [releases](https://github.com/navikt/teamdokumenthandtering-avro-schemas/releases). Det opprettes ikke tags pr commit, så den må opprettes manuelt i release-prosessen. Velg passende semantisk versjonering basert på endringene som er gjort siden forrige release.
 
-Maven-pakken, med endringslogg akkumulert av release-drafter, publiseres kun ved release.
+Maven-pakken publiseres automatisk ved publisering av en release.
 
 ### Henvendelser
 Spørsmål om koden eller prosjektet kan rettes til [Slack-kanalen for \#Team Dokumentløsninger](https://nav-it.slack.com/archives/C6W9E5GPJ).


### PR DESCRIPTION
Versjon (tag) opprettes nå manuelt som en del av release prosessen. Den som publiserer releasen velger passende semantisk versjon basert på endringer siden forrige release.